### PR TITLE
Support VIDE 'voro' branch (v2) file formats

### DIFF
--- a/vorothreshold/main.py
+++ b/vorothreshold/main.py
@@ -9,7 +9,8 @@ from numba.core import types
 from numba.typed import Dict
 from numba import jit, prange, set_num_threads, get_num_threads, get_thread_id
 
-from . read_funcs import read_adjfile, read_voronoi_vide, load_pickle_safe
+from . read_funcs import (read_adjfile, read_voronoi_vide, load_pickle_safe,
+                          is_vide_voro, find_adjfile, read_void_database)
 from . masks import borders_mask_bruteforce, dist_limit_mask, borders_mask, borders_mask_inner
 from . overlaps import select_overlaps, overlapping_fraction, center_in_void, closest_voro, select_overlaps_center_in_void
 from . utilities import from_XYZ_to_rRAdec, from_rRAdec_to_XYZ, ComovingDistanceOverh, RedshiftFromComovingDistanceOverh, StrHminSec
@@ -208,16 +209,21 @@ class voronoi_threshold_finder:
             verboseprint('    Loading VIDE data.',flush=True)
             t0 = time.time()
 
-            adjfile = glob.glob(vide_path+'/adj_*')[0] #vide_path + '/adj_' + vide_out_name + '.dat'
+            adjfile = find_adjfile(vide_path)
             neighbor_ptr, neighbor_ids = read_adjfile(adjfile)
 
-            # recover vide_out_name
-            vide_out_name = adjfile.split('adj_')[1].split('.dat')[0]
-            #if ID_core is None:
-            # Load ids of cells belonging to minima
-            ID_core = np.loadtxt(vide_path+'/untrimmed_voidDesc_all_'+vide_out_name+'.out', comments='#', skiprows=2)[:,2].astype(np.int64)
-            # Load Voronoi cells volume, ids and tracers position
-            
+            if is_vide_voro(vide_path):
+                # voro branch: single void_database.out, no per-sample suffix
+                vide_out_name = ''
+                _db = read_void_database(vide_path)
+                ID_core = _db['core_ID'].astype(np.int64)
+                _num_part_db = _db['num_part']
+            else:
+                # master branch: parse sample name from adj_<sample>.dat
+                vide_out_name = os.path.basename(adjfile).replace('adj_','').replace('.dat','')
+                ID_core = np.loadtxt(vide_path+'/untrimmed_voidDesc_all_'+vide_out_name+'.out', comments='#', skiprows=2)[:,2].astype(np.int64)
+                _num_part_db = None
+
 
             if lightcone:
                 ids_voro, self.VoroVol, self.VoroXYZ, self.RAvoro, self.DECvoro, redshift_voro = read_voronoi_vide(vide_path,vide_out_name)
@@ -273,8 +279,10 @@ class voronoi_threshold_finder:
             verboseprint('        done:',StrHminSec(time.time()-t0),flush=True)
 
             if max_num_part <= 0:
-
-                max_num_part = int(5 * np.max(np.loadtxt(vide_path+'/untrimmed_centers_all_'+vide_out_name+'.out', comments="#")[:,9]))
+                if _num_part_db is not None:
+                    max_num_part = int(5 * np.max(_num_part_db)) if _num_part_db.size else 0
+                else:
+                    max_num_part = int(5 * np.max(np.loadtxt(vide_path+'/untrimmed_centers_all_'+vide_out_name+'.out', comments="#")[:,9]))
                 verboseprint('    max_num_part < 0: authomatically set to 5 * max(num_part):',max_num_part,flush=True)
 
             if (neighbor_ptr is None) or (neighbor_ids is None):

--- a/vorothreshold/read_funcs.py
+++ b/vorothreshold/read_funcs.py
@@ -1,7 +1,6 @@
 import glob
 import numpy as np
 import struct
-from netCDF4 import Dataset
 from numba import jit
 import joblib
 import subprocess
@@ -12,8 +11,133 @@ import shutil
 #from typing import List
 
 
-__all__ = ['read_voronoi_vide','read_voronoi_vide', 'voro_in_vide_voids', 'vide_voids_cat','load_pickle_safe'
-           'read_adjfile', 'read_adjfile_safe']
+__all__ = ['read_voronoi_vide', 'voro_in_vide_voids', 'vide_voids_cat', 'load_pickle_safe',
+           'read_adjfile', 'read_adjfile_safe',
+           'is_vide_voro', 'read_void_database', 'find_adjfile',
+           'find_void_zone_file', 'find_zone_part_file']
+
+
+# ---------------------------------------------------------------------------
+# VIDE format detection and helpers (v1 "master" vs v2 "voro" branch)
+# ---------------------------------------------------------------------------
+# v2 (voro) consolidates per-tracer data in tracers.dat (HDF5) and the void
+# catalog in void_database.out, and renames a few binary files. v1 (master)
+# wrote zobov_slice_<sample>.par + vol_<sample>.dat + binary zobov_slice_<sample>
+# plus untrimmed_*_*.out catalog files. These helpers route to the right one.
+
+def is_vide_voro(vide_out):
+    return os.path.exists(os.path.join(os.path.expanduser(vide_out), 'tracers.dat'))
+
+
+def find_adjfile(vide_out):
+    voro = os.path.join(os.path.expanduser(vide_out), 'adjacencies.dat')
+    if os.path.exists(voro):
+        return voro
+    matches = glob.glob(os.path.join(os.path.expanduser(vide_out), 'adj_*'))
+    if not matches:
+        raise FileNotFoundError('No adjacency file found in '+str(vide_out))
+    return matches[0]
+
+
+def find_void_zone_file(vide_out):
+    voro = os.path.join(os.path.expanduser(vide_out), 'zobov_void_zone_members.dat')
+    if os.path.exists(voro):
+        return voro
+    matches = glob.glob(os.path.join(os.path.expanduser(vide_out), 'voidZone_*'))
+    if not matches:
+        raise FileNotFoundError('No void-zone file found in '+str(vide_out))
+    return matches[0]
+
+
+def find_zone_part_file(vide_out, sample_name=None):
+    voro = os.path.join(os.path.expanduser(vide_out), 'zobov_zone_part_members.dat')
+    if os.path.exists(voro):
+        return voro
+    if sample_name is None:
+        matches = glob.glob(os.path.join(os.path.expanduser(vide_out), 'voidPart_*'))
+        if not matches:
+            raise FileNotFoundError('No zone-part file found in '+str(vide_out))
+        return matches[0]
+    return os.path.join(os.path.expanduser(vide_out), 'voidPart_'+sample_name+'.dat')
+
+
+_VOID_DATABASE_COLS = {
+    'voidID':       (0,  np.int32),
+    'type':         (1,  None),  # string column
+    'cx':           (2,  np.float64),
+    'cy':           (3,  np.float64),
+    'cz':           (4,  np.float64),
+    'volume_norm':  (5,  np.float64),
+    'volume':       (6,  np.float64),
+    'radius':       (7,  np.float64),
+    'redshift':     (8,  np.float64),
+    'RA':           (9,  np.float64),
+    'DEC':          (10, np.float64),
+    'dens_contr':   (11, np.float64),
+    'max_extent':   (12, np.float64),
+    'nearest_edge': (13, np.float64),
+    'num_part':     (14, np.int32),
+    'parent_ID':    (15, np.int32),
+    'tree_level':   (16, np.int32),
+    'num_children': (17, np.int32),
+    'central_dens': (18, np.float64),
+    'core_ID':      (19, np.int64),
+    'core_dens':    (20, np.float64),
+    'zone_vol':     (21, np.float64),
+    'zone_part':    (22, np.int32),
+    'void_zone':    (23, np.int32),
+    'void_prob':    (24, np.float64),
+    'ellip':        (25, np.float64),
+}
+
+
+def read_void_database(vide_out, dataPortion='all', untrimmed=True):
+    """Parse void_database.out (VIDE voro branch).
+
+    Returns a dict with named columns. dataPortion / untrimmed reproduce the
+    pre-trim filename semantics from VIDE 1.0:
+        untrimmed=True                  -> all rows (default)
+        dataPortion='all',  untrimmed=False  -> exclude type == 'edge'
+        dataPortion='central'                -> keep only type == 'central'
+    """
+    path = os.path.join(os.path.expanduser(vide_out), 'void_database.out')
+    if not os.path.exists(path):
+        raise FileNotFoundError(path)
+
+    arr = np.genfromtxt(path, comments='#', dtype=str)
+    if arr.size == 0 or arr.shape[0] == 0:
+        out = {kk: np.empty(0, dtype=tt if tt is not None else 'U16')
+               for kk, (_, tt) in _VOID_DATABASE_COLS.items()}
+        out['barycenter']   = np.empty((0, 3), dtype=np.float64)
+        out['eigenvalues']  = np.empty((0, 3), dtype=np.float64)
+        out['eigenvec1']    = np.empty((0, 3), dtype=np.float64)
+        out['eigenvec2']    = np.empty((0, 3), dtype=np.float64)
+        out['eigenvec3']    = np.empty((0, 3), dtype=np.float64)
+        return out
+    if arr.ndim == 1:
+        arr = arr[None, :]
+
+    if not untrimmed:
+        if dataPortion == 'central':
+            mask = arr[:, 1] == 'central'
+        else:
+            mask = arr[:, 1] != 'edge'
+        arr = arr[mask]
+
+    out = dict()
+    for name, (col, tt) in _VOID_DATABASE_COLS.items():
+        if tt is None:
+            out[name] = arr[:, col]
+        else:
+            out[name] = arr[:, col].astype(tt)
+
+    out['barycenter']  = np.stack([out.pop('cx'), out.pop('cy'), out.pop('cz')], axis=1)
+    out['eigenvalues'] = arr[:, 26:29].astype(np.float64)
+    out['eigenvec1']   = arr[:, 29:32].astype(np.float64)
+    out['eigenvec2']   = arr[:, 32:35].astype(np.float64)
+    out['eigenvec3']   = arr[:, 35:38].astype(np.float64)
+
+    return out
 
 
 def load_pickle_safe(pkl_file):
@@ -196,7 +320,53 @@ def read_adjfile_safe(adjfile):
 
 
 
-def read_voronoi_vide(vide_out,sample_name=None):
+def _read_voronoi_vide_voro(vide_out):
+    """Reader for the VIDE 'voro' branch: tracers.dat (HDF5) holds everything."""
+    tracers_file = os.path.join(os.path.expanduser(vide_out), 'tracers.dat')
+    with h5py.File(tracers_file, 'r') as ff:
+        x_min = float(ff.attrs['range_x_min']);  x_max = float(ff.attrs['range_x_max'])
+        y_min = float(ff.attrs['range_y_min']);  y_max = float(ff.attrs['range_y_max'])
+        z_min = float(ff.attrs['range_z_min']);  z_max = float(ff.attrs['range_z_max'])
+        Np = int(ff.attrs['num_tracers'])
+
+        x = ff['x'][:].astype(np.float32) - np.float32(x_min)
+        y = ff['y'][:].astype(np.float32) - np.float32(y_min)
+        z = ff['z'][:].astype(np.float32) - np.float32(z_min)
+
+        if 'RA' in ff:
+            RA = ff['RA'][:].astype(np.float32)
+        else:
+            RA = np.zeros(Np, dtype=np.float32)
+        if 'Dec' in ff:
+            Dec = ff['Dec'][:].astype(np.float32)
+        else:
+            Dec = np.zeros(Np, dtype=np.float32)
+        if 'redshifts' in ff:
+            redshift = ff['redshifts'][:].astype(np.float32)
+        else:
+            redshift = np.zeros(Np, dtype=np.float32)
+
+        uniqueID = ff['unique_ids'][:]
+
+        # Raw voro++ output. In observation mode, edge-flagged cells have
+        # inflated tails; the watershed sees the walled form (1e-27). To
+        # reproduce VIDE 1.0's vol_*.dat (which was already the walled form
+        # with edge cells effectively excluded), apply the same wall here.
+        vols = ff['volumes'][:].astype(np.float32)
+        if 'edge_flags' in ff:
+            vols[ff['edge_flags'][:] > 0] = np.float32(1e-27)
+
+    boxLen = np.array([x_max - x_min, y_max - y_min, z_max - z_min])
+    videnorm = Np / np.prod(boxLen)
+
+    VoroXYZ = np.stack([x, y, z], axis=1)
+
+    return uniqueID, vols / videnorm, VoroXYZ, RA, Dec, redshift
+
+
+def _read_voronoi_vide_master(vide_out, sample_name=None):
+    """Reader for the legacy VIDE 'master' branch (zobov_slice_<name>.par + vol_<name>.dat)."""
+    from netCDF4 import Dataset  # only required for v1; deferred import keeps v2 dependency-free
 
     if sample_name is None:
         infoFile = glob.glob(os.path.expanduser(vide_out)+'/zobov_slice_*.par')[0]
@@ -205,7 +375,7 @@ def read_voronoi_vide(vide_out,sample_name=None):
         infoFile = os.path.expanduser(vide_out)+"/zobov_slice_"+sample_name+".par"
 
     # load box and part info
-    
+
     File = Dataset(infoFile, 'r')
     ranges = np.zeros((3,2))
     ranges[0][0] = getattr(File, 'range_x_min')
@@ -218,8 +388,6 @@ def read_voronoi_vide(vide_out,sample_name=None):
     numPartTot = getattr(File, 'mask_index')
     File.close()
     boxLen = ranges[:,1] - ranges[:,0]
-
-
 
     # load Voronoi volume (unnormalized)
     volFile = os.path.expanduser(vide_out)+"/vol_"+sample_name+".dat"
@@ -238,22 +406,16 @@ def read_voronoi_vide(vide_out,sample_name=None):
         chk = np.fromfile(File, dtype=np.int32,count=1)
         x = np.fromfile(File, dtype=np.float32,count=Np)
         x *= boxLen[0]
-        #if isObservation != 1:
-        #x += ranges[0][0]
         chk = np.fromfile(File, dtype=np.int32,count=1)
 
         chk = np.fromfile(File, dtype=np.int32,count=1)
         y = np.fromfile(File, dtype=np.float32,count=Np)
         y *= boxLen[1]
-        #if isObservation != 1:
-        #y += ranges[1][0]
         chk = np.fromfile(File, dtype=np.int32,count=1)
 
         chk = np.fromfile(File, dtype=np.int32,count=1)
         z = np.fromfile(File, dtype=np.float32,count=Np)
         z *= boxLen[2]
-        #if isObservation != 1:
-        #z += ranges[2][0]
         chk = np.fromfile(File, dtype=np.int32,count=1)
 
         chk = np.fromfile(File, dtype=np.int32,count=1)
@@ -272,21 +434,27 @@ def read_voronoi_vide(vide_out,sample_name=None):
         uniqueID = np.fromfile(File, dtype=np.int64,count=Np)
         chk = np.fromfile(File, dtype=np.int32,count=1)
 
-    # compute Voronoi volume normalization
     videnorm = Np / np.prod(boxLen)
-
-
-    # compute Voronoi quantities
     c_kms = 299792.458
 
     uniqueID = uniqueID[:numPartTot]
-    #VoroVol = vols / videnorm
     VoroXYZ = np.array([x[:numPartTot],y[:numPartTot],z[:numPartTot]]).T
     RA = RA[:numPartTot]
     Dec = Dec[:numPartTot]
     redshift = redshift[:numPartTot]/c_kms
 
     return uniqueID, vols / videnorm, VoroXYZ, RA, Dec, redshift
+
+
+def read_voronoi_vide(vide_out, sample_name=None):
+    """Load per-tracer info from a VIDE sample directory.
+
+    Auto-detects between the new 'voro' branch (tracers.dat HDF5) and the
+    legacy 'master' branch (zobov_slice_<sample>.par + vol_<sample>.dat).
+    """
+    if is_vide_voro(vide_out):
+        return _read_voronoi_vide_voro(vide_out)
+    return _read_voronoi_vide_master(vide_out, sample_name=sample_name)
 
 
 
@@ -300,11 +468,12 @@ class update_dict:
 
 class OLD_voro_in_vide_voids:
     def __init__(self,vide_out,sample_name=None,dataPortion="all",untrimmed=True):
+        zoneFile = find_void_zone_file(vide_out)
         if sample_name is None:
-            zoneFile = glob.glob(vide_out+'/voidZone_*')[0]
-            sample_name = zoneFile.replace(vide_out+'/voidZone_','').replace('.dat','')
-        else:
-            zoneFile = os.path.expanduser(vide_out)+"/voidZone_"+sample_name+".dat"
+            try:
+                sample_name = zoneFile.replace(os.path.expanduser(vide_out)+'/voidZone_','').replace('.dat','')
+            except Exception:
+                sample_name = ''
         void2Zones = []
         with open(zoneFile, mode="rb") as File:
             numZonesTot = np.fromfile(File, dtype=np.int32,count=1)[0]
@@ -320,7 +489,7 @@ class OLD_voro_in_vide_voids:
 
 
         #print("Loading particle-zone membership info...")
-        zonePartFile = os.path.expanduser(vide_out)+"/voidPart_"+sample_name+".dat"
+        zonePartFile = find_zone_part_file(vide_out, sample_name=sample_name)
         zones2Parts = []
         with open(zonePartFile) as File:
             chk = np.fromfile(File, dtype=np.int32,count=1)
@@ -335,12 +504,12 @@ class OLD_voro_in_vide_voids:
         self.zones2Parts = zones2Parts
 
 
-        if untrimmed:
-            prefix = "untrimmed_"
+        if is_vide_voro(vide_out):
+            db = read_void_database(vide_out, dataPortion=dataPortion, untrimmed=untrimmed)
+            self.voidID = db['voidID']
         else:
-            prefix = ""
-
-        self.voidID = np.loadtxt(os.path.expanduser(vide_out)+"/"+prefix+"voidDesc_"+dataPortion+"_"+sample_name+".out", comments="#", skiprows=2)[:,1].astype(np.int32)
+            prefix = "untrimmed_" if untrimmed else ""
+            self.voidID = np.loadtxt(os.path.expanduser(vide_out)+"/"+prefix+"voidDesc_"+dataPortion+"_"+sample_name+".out", comments="#", skiprows=2)[:,1].astype(np.int32)
 
     def get_voro_from_uniqueID(self,voidID):
 
@@ -397,12 +566,7 @@ def load_void_zone_part(zonePartFile):
 
 def load_partzone(vide_out,sample_name=None,dataPortion="all",untrimmed=True):
     #print("Loading particle-zone membership info...")
-    if sample_name is None:
-        zoneFile = glob.glob(os.path.expanduser(vide_out)+'/voidZone_*')[0]
-        sample_name = zoneFile.replace(os.path.expanduser(vide_out)+'/voidZone_','').replace('.dat','')
-    else:
-        zoneFile = os.path.expanduser(vide_out)+"/voidZone_"+sample_name+".dat"
-    zonePartFile = os.path.expanduser(vide_out)+"/voidPart_"+sample_name+".dat"
+    zonePartFile = find_zone_part_file(vide_out, sample_name=sample_name)
     zones2Parts = []
     with open(zonePartFile, mode="rb") as File:
         num_bytes = len(File.read())
@@ -410,7 +574,7 @@ def load_partzone(vide_out,sample_name=None,dataPortion="all",untrimmed=True):
     with open(zonePartFile, mode="rb") as File:
 
         data = File.read(num_bytes)
-    
+
         # Read all neighbors' IDs in bulk
         raw_data = np.frombuffer(data, dtype=np.int32)
 
@@ -435,26 +599,20 @@ def load_partzone_inner(raw_data):
 
 class voro_in_vide_voids:
     def __init__(self,vide_out,sample_name=None,dataPortion="all",untrimmed=True):
-        if sample_name is None:
-            zoneFile = glob.glob(os.path.expanduser(vide_out)+'/voidZone_*')[0]
-            sample_name = zoneFile.replace(os.path.expanduser(vide_out)+'/voidZone_','').replace('.dat','')
-        else:
-            zoneFile = os.path.expanduser(vide_out)+"/voidZone_"+sample_name+".dat"
-
+        zoneFile = find_void_zone_file(vide_out)
         self.numZones, self.zoneIDs = load_void_zones_inner(load_void_zone_part(zoneFile))
 
-        zonePartFile = os.path.expanduser(vide_out)+"/voidPart_"+sample_name+".dat"
+        zonePartFile = find_zone_part_file(vide_out, sample_name=sample_name)
         self.numPart, self.partID = load_partzone_inner(load_void_zone_part(zonePartFile))
 
-
-        if untrimmed:
-            prefix = "untrimmed_"
-        else:
-            prefix = ""
-
         try:
-            self.voidID = np.loadtxt(os.path.expanduser(vide_out)+"/"+prefix+"voidDesc_"+dataPortion+"_"+sample_name+".out", comments="#", skiprows=2)[:,1].astype(np.int32)
-        except:
+            if is_vide_voro(vide_out):
+                db = read_void_database(vide_out, dataPortion=dataPortion, untrimmed=untrimmed)
+                self.voidID = db['voidID']
+            else:
+                prefix = "untrimmed_" if untrimmed else ""
+                self.voidID = np.loadtxt(os.path.expanduser(vide_out)+"/"+prefix+"voidDesc_"+dataPortion+"_"+sample_name+".out", comments="#", skiprows=2)[:,1].astype(np.int32)
+        except Exception:
             self.voidID = np.empty(0,dtype=np.int32)
 
     def get_voro_from_uniqueID(self,voidID):
@@ -477,189 +635,186 @@ class voro_in_vide_voids:
     
 
 
-def vide_voids_cat(vide_out_dir,sample_name=None,dataPortion='all',untrimmed=True,as_dict=True,values_out=None):
-    if untrimmed:
-        prefix = "untrimmed_"
-    else:
-        prefix = ""
+_VIDE_CAT_KEYS_CENTER = ['barycenter','volume_norm','radius','redshift','volume','voidID',
+                         'dens_contr','num_part','parent_ID','tree_level','num_children','central_dens']
+_VIDE_CAT_KEYS_SKY    = ['RA','DEC']
+_VIDE_CAT_KEYS_DESC   = ['file_void','core_ID','core_dens','zone_vol','zone_part','void_zone','void_prob']
+_VIDE_CAT_KEYS_CORE   = ['core_pos','RAcore','DECcore','redshift_core']
+_VIDE_CAT_KEYS_SHAPE  = ['ellip','eigenvalues','eigenvec1','eigenvec2','eigenvec3']
+_VIDE_CAT_KEYS_INFO   = ['num_part_tot']
+_VIDE_CAT_KEYS_ALL    = (_VIDE_CAT_KEYS_CENTER + _VIDE_CAT_KEYS_SKY + _VIDE_CAT_KEYS_DESC
+                         + _VIDE_CAT_KEYS_CORE + _VIDE_CAT_KEYS_SHAPE + _VIDE_CAT_KEYS_INFO)
+
+
+def _vide_voids_cat_voro(vide_out_dir, dataPortion, untrimmed, want_core, want_info):
+    """Read a VIDE 'voro' branch sample directory into the legacy dict layout."""
+    db = read_void_database(vide_out_dir, dataPortion=dataPortion, untrimmed=untrimmed)
+
+    out = dict()
+    out['barycenter']   = db['barycenter'].astype(np.float64)
+    out['volume_norm']  = db['volume_norm']
+    out['radius']       = db['radius']
+    out['redshift']     = db['redshift']
+    out['volume']       = db['volume']
+    out['voidID']       = db['voidID']
+    out['dens_contr']   = db['dens_contr']
+    out['num_part']     = db['num_part']
+    out['parent_ID']    = db['parent_ID']
+    out['tree_level']   = db['tree_level']
+    out['num_children'] = db['num_children']
+    out['central_dens'] = db['central_dens']
+
+    out['RA']  = db['RA']
+    out['DEC'] = db['DEC']
+
+    # voidDesc fields. v1's "file_void" was the watershed void ID — same as
+    # voidID in v2. void_prob is now in the same row.
+    out['file_void'] = db['voidID']
+    out['core_ID']   = db['core_ID']
+    out['core_dens'] = db['core_dens']
+    out['zone_vol']  = db['zone_vol']
+    out['zone_part'] = db['zone_part']
+    out['void_zone'] = db['void_zone']
+    out['void_prob'] = db['void_prob']
+
+    out['ellip']        = db['ellip']
+    out['eigenvalues']  = db['eigenvalues']
+    out['eigenvec1']    = db['eigenvec1']
+    out['eigenvec2']    = db['eigenvec2']
+    out['eigenvec3']    = db['eigenvec3']
+
+    if want_core:
+        _, _, VoroXYZ, RAvoro, DECvoro, redshift_voro = read_voronoi_vide(vide_out_dir)
+        core = out['core_ID']
+        out['core_pos']      = VoroXYZ[core, :]
+        out['RAcore']        = RAvoro[core]
+        out['DECcore']       = DECvoro[core]
+        out['redshift_core'] = redshift_voro[core]
+
+    if want_info:
+        with h5py.File(os.path.join(os.path.expanduser(vide_out_dir), 'tracers.dat'), 'r') as ff:
+            out['num_part_tot'] = int(ff.attrs['num_tracers'])
+
+    return out
+
+
+def _vide_voids_cat_master(vide_out_dir, sample_name, dataPortion, untrimmed,
+                           do_center, do_sky, do_desc, do_core, do_shape, do_info):
+    """Legacy reader: reproduces the old multi-file VIDE 1.0 catalog layout."""
+    from netCDF4 import Dataset
+
+    prefix = "untrimmed_" if untrimmed else ""
+
     if sample_name is None:
-        path_test = os.path.expanduser(vide_out_dir)+"/"+prefix+"centers_"+dataPortion+"_"#+sample_name+".out"
+        path_test = os.path.expanduser(vide_out_dir)+"/"+prefix+"centers_"+dataPortion+"_"
         center_file = glob.glob(path_test+'*')[0]
         sample_name = center_file.replace(path_test,'').replace('.out','')
-        
-    keys_center = ['barycenter','volume_norm','radius','redshift','volume','voidID','dens_contr','num_part',
-                'parent_ID','tree_level','num_children','central_dens']
-    keys_sky = ['RA','DEC']
-    keys_desc = ['file_void','core_ID','core_dens','zone_vol','zone_part', 'void_zone', 'void_prob']
-    keys_core = ['core_pos','RAcore','DECcore','redshift_core']
-    keys_shape = ['ellip','eigenvalues','eigenvec1','eigenvec2','eigenvec3']
-    keys_info = ['num_part_tot']
-    # void ID, ellip, eig(1), eig(2), eig(3), eigv(1)-x, eiv(1)-y, eigv(1)-z, eigv(2)-x, eigv(2)-y, eigv(2)-z, eigv(3)-x, eigv(3)-y, eigv(3)-z
-    keys_all = keys_center + keys_sky + keys_desc + keys_core + keys_shape + keys_info
-    #keys_all = ['barycenter','volume_norm','radius','redshift','volume','voidID','dens_contr','num_part',
-    #            'parent_ID','tree_level','num_children','central_dens','RA','DEC',
-    #            'coreID','core_dens','core_pos','RAcore','DECcore','redshift_core']
-    
-    do_center = False
-    do_sky = False
-    do_desc = False
-    do_core = False
-    do_shape = False
-    do_info = False
-    if values_out is None:
-        selected_output = False
-        do_center = True
-        do_sky = True
-        do_desc = True
-        do_core = True
-        do_shape = True
-        do_info = True
-    else:
-        selected_output = True
-        do_core = False
-        if np.isscalar(values_out):
-            values_out = [values_out]
-        for kk in values_out:
-            if kk not in keys_all:
-                all_k_str = ''
-                for k_ok in values_out:
-                    all_k_str += k_ok+', '
-                
-                raise ValueError(kk + ' key unknown. available keys: '+all_k_str[:-2])
-            
-        for kk in keys_center:
-            if kk in values_out:
-                do_center = True
-                break
-        for kk in keys_sky:
-            if kk in values_out:
-                do_sky = True
-                break
-        for kk in keys_desc:
-            if kk in values_out:
-                do_desc = True
-                break
-        for kk in keys_core:
-            if kk in values_out:
-                do_core = True
-                break
-        for kk in keys_shape:
-            if kk in values_out:
-                do_shape = True
-                break
-        for kk in keys_info:
-            if kk in values_out:
-                do_info = True
-                break
 
-    exception = False
-    dict_out = dict()
+    out = dict()
+
     if do_center:
         catData = np.loadtxt(os.path.expanduser(vide_out_dir)+"/"+prefix+"centers_"+dataPortion+"_"+sample_name+".out", comments="#")
-        # center x,y,z (Mpc/h), volume (normalized), radius (Mpc/h), redshift, volume (Mpc/h^3), void ID, density contrast, num part, parent ID, tree level, number of children, central density
         if catData.shape == (0,):
             catData = np.empty((0,14),dtype=np.float32)
-            exception = True
-            #raise Warning('No voids detected.')
-        
-        dict_out['barycenter'] = catData[:,:3]
-        dict_out['volume_norm'] = catData[:,3]
-        dict_out['radius'] = catData[:,4]
-        dict_out['redshift'] = catData[:,5]
-        dict_out['volume'] = catData[:,6]
-        dict_out['voidID'] = catData[:,7].astype(np.int32)
-        dict_out['dens_contr'] = catData[:,8]
-        dict_out['num_part'] = catData[:,9].astype(np.int32)
-        dict_out['parent_ID'] = catData[:,10].astype(np.int32)
-        dict_out['tree_level'] = catData[:,11].astype(np.int32)
-        dict_out['num_children'] = catData[:,12].astype(np.int32)
-        dict_out['central_dens'] = catData[:,13]
+        out['barycenter']   = catData[:,:3]
+        out['volume_norm']  = catData[:,3]
+        out['radius']       = catData[:,4]
+        out['redshift']     = catData[:,5]
+        out['volume']       = catData[:,6]
+        out['voidID']       = catData[:,7].astype(np.int32)
+        out['dens_contr']   = catData[:,8]
+        out['num_part']     = catData[:,9].astype(np.int32)
+        out['parent_ID']    = catData[:,10].astype(np.int32)
+        out['tree_level']   = catData[:,11].astype(np.int32)
+        out['num_children'] = catData[:,12].astype(np.int32)
+        out['central_dens'] = catData[:,13]
 
     if do_sky:
         catData = np.loadtxt(os.path.expanduser(vide_out_dir)+"/"+prefix+"sky_positions_"+dataPortion+"_"+sample_name+".out")
         if catData.shape == (0,):
             catData = np.empty((0,5),dtype=np.float32)
-            if not exception:
-                exception = True
-                #raise Warning('No voids detected.')
-        dict_out['RA'] = catData[:,0]
-        dict_out['DEC'] = catData[:,1]
-
-
+        out['RA']  = catData[:,0]
+        out['DEC'] = catData[:,1]
 
     if do_desc | do_core:
-        #'file_void','core_ID','core_dens','zone_vol','zone_part', 'void_prob'
-        #ID FileVoid# CoreParticle CoreDens ZoneVol Zone#Part Void#Zones VoidVol Void#Part VoidDensContrast VoidProb
-
         catData = np.loadtxt(os.path.expanduser(vide_out_dir)+"/"+prefix+"voidDesc_"+dataPortion+"_"+sample_name+".out", comments="#", skiprows=2)
         if catData.shape == (0,):
             catData = np.empty((0,11),dtype=np.float32)
-            if not exception:
-                exception = True
-                #raise Warning('No voids detected.')
-
-        dict_out['file_void'] = catData[:,1].astype(np.int32)
-        dict_out['core_ID'] = catData[:,2].astype(np.int32)
-        dict_out['core_dens'] = catData[:,3]
-        dict_out['zone_vol'] = catData[:,4]
-        dict_out['zone_part'] = catData[:,5].astype(np.int32)
-        dict_out['void_zone'] = catData[:,6].astype(np.int32)
-        dict_out['void_prob'] = catData[:,10]
-
+        out['file_void'] = catData[:,1].astype(np.int32)
+        out['core_ID']   = catData[:,2].astype(np.int32)
+        out['core_dens'] = catData[:,3]
+        out['zone_vol']  = catData[:,4]
+        out['zone_part'] = catData[:,5].astype(np.int32)
+        out['void_zone'] = catData[:,6].astype(np.int32)
+        out['void_prob'] = catData[:,10]
         del catData
-        
 
     if do_core:
-        voro_id, VolCell, VoroXYZ, RAvoro, DECvoro, redshift_voro = read_voronoi_vide(os.path.expanduser(vide_out_dir),sample_name)
-        if not exception:
-            exception = True
-            #raise Warning('No voids detected.')
-        del voro_id, VolCell
-
-        dict_out['core_pos'] = VoroXYZ[dict_out['core_ID'],:]
-        dict_out['RAcore'] = RAvoro[dict_out['core_ID']]
-        dict_out['DECcore'] = DECvoro[dict_out['core_ID']]
-        dict_out['redshift_core'] = redshift_voro[dict_out['core_ID']]
-
-        del VoroXYZ, RAvoro, DECvoro, redshift_voro
-
+        _, _, VoroXYZ, RAvoro, DECvoro, redshift_voro = read_voronoi_vide(os.path.expanduser(vide_out_dir), sample_name)
+        core = out['core_ID']
+        out['core_pos']      = VoroXYZ[core, :]
+        out['RAcore']        = RAvoro[core]
+        out['DECcore']       = DECvoro[core]
+        out['redshift_core'] = redshift_voro[core]
 
     if do_shape:
         fileName = os.path.expanduser(vide_out_dir)+"/"+prefix+"shapes_"+dataPortion+"_"+sample_name+".out"
         try:
             ellipticity = np.loadtxt(fileName, comments="#")[:,1:14]
-        except:
+        except Exception:
             if np.loadtxt(fileName, comments="#").shape == (0,):
                 ellipticity = np.empty((0,14),dtype=np.float32)
-                if not exception:
-                    exception = True
-                    #raise Warning('No voids detected.')
-        dict_out['ellip'] = ellipticity[:,0]
-        dict_out['eigenvalues'] = ellipticity[:,1:4]
-        dict_out['eigenvec1'] = ellipticity[:,4:7]
-        dict_out['eigenvec2'] = ellipticity[:,7:10]
-        dict_out['eigenvec3'] = ellipticity[:,10:13]
-        del ellipticity
+        out['ellip']       = ellipticity[:,0]
+        out['eigenvalues'] = ellipticity[:,1:4]
+        out['eigenvec1']   = ellipticity[:,4:7]
+        out['eigenvec2']   = ellipticity[:,7:10]
+        out['eigenvec3']   = ellipticity[:,10:13]
+
     if do_info:
         infoFile = os.path.expanduser(vide_out_dir)+"/zobov_slice_"+sample_name+".par"
-
         File = Dataset(infoFile, 'r')
-        dict_out['num_part_tot'] = getattr(File, 'mask_index')
+        out['num_part_tot'] = getattr(File, 'mask_index')
         File.close()
 
+    return out
+
+
+def vide_voids_cat(vide_out_dir, sample_name=None, dataPortion='all', untrimmed=True,
+                   as_dict=True, values_out=None):
+    """Read a VIDE void catalog into a dict of named arrays.
+
+    Auto-routes between the new 'voro' branch (single void_database.out +
+    tracers.dat) and the legacy 'master' branch (untrimmed_*_*.out family).
+    """
+    if values_out is None:
+        selected_output = False
+        do_center = do_sky = do_desc = do_core = do_shape = do_info = True
+    else:
+        selected_output = True
+        if np.isscalar(values_out):
+            values_out = [values_out]
+        for kk in values_out:
+            if kk not in _VIDE_CAT_KEYS_ALL:
+                raise ValueError(kk + ' key unknown. available keys: '+', '.join(_VIDE_CAT_KEYS_ALL))
+        do_center = any(kk in _VIDE_CAT_KEYS_CENTER for kk in values_out)
+        do_sky    = any(kk in _VIDE_CAT_KEYS_SKY    for kk in values_out)
+        do_desc   = any(kk in _VIDE_CAT_KEYS_DESC   for kk in values_out)
+        do_core   = any(kk in _VIDE_CAT_KEYS_CORE   for kk in values_out)
+        do_shape  = any(kk in _VIDE_CAT_KEYS_SHAPE  for kk in values_out)
+        do_info   = any(kk in _VIDE_CAT_KEYS_INFO   for kk in values_out)
+
+    if is_vide_voro(vide_out_dir):
+        dict_out = _vide_voids_cat_voro(vide_out_dir, dataPortion, untrimmed,
+                                        want_core=do_core, want_info=do_info)
+    else:
+        dict_out = _vide_voids_cat_master(vide_out_dir, sample_name, dataPortion, untrimmed,
+                                          do_center, do_sky, do_desc, do_core, do_shape, do_info)
 
     if as_dict:
         if selected_output:
-            new_dict = dict()
-            for kk in values_out:
-                new_dict[kk] = dict_out[kk]
-            return new_dict
-        else:
-            return dict_out
-    
-    elif selected_output:
+            return {kk: dict_out[kk] for kk in values_out}
+        return dict_out
+
+    if selected_output:
         return (dict_out[kk] for kk in values_out)
-    
-    else:
-        return (dict_out[kk] for kk in keys_all)
-        
+    return (dict_out[kk] for kk in _VIDE_CAT_KEYS_ALL)


### PR DESCRIPTION
The new VIDE consolidates per-tracer data into a single tracers.dat HDF5 (with edge_flags, RA/Dec/redshifts, x/y/z, volumes, unique_ids) and the void catalog into a single void_database.out, and renames the zone/part/adjacency binaries. Reading is now auto-routed: if tracers.dat is present in the sample dir, the v2 reader runs; otherwise the existing v1 reader (zobov_slice_*.par + vol_*.dat + untrimmed_*_*.out) runs unchanged. Existing data keeps working.

Changes in read_funcs.py:
- new helpers is_vide_voro / find_adjfile / find_void_zone_file / find_zone_part_file / read_void_database
- read_voronoi_vide split into _voro and _master backends; the v2 path pulls coords/RA/Dec/redshifts from tracers.dat and walls edge cells to 1e-27 to match v1's pre-walled vol_*.dat
- voro_in_vide_voids and OLD_voro_in_vide_voids resolve zone/part files via the renamed v2 names and read voidIDs from void_database.out
- vide_voids_cat split into _voro and _master backends, exposing the same dict layout (barycenter, voidID, RA/DEC, core_*, ellip, eigenvalues/eigenvec1-3, num_part_tot)
- netCDF4 import deferred to v1 backends; pure-v2 environments don't need it any more
- fix pre-existing missing comma in __all__ (was concatenating "load_pickle_safe" and "read_adjfile" into one symbol)

Changes in main.py:
- voronoi_threshold_finder loads adjacencies via find_adjfile and reads ID_core / num_part from void_database.out when on the voro branch, falling back to untrimmed_voidDesc_/untrimmed_centers_ on master