### PR TITLE
Fix TypeError in compute_overlaps_all_parallel empty-array guard

### DIFF
--- a/vorothreshold/main.py
+++ b/vorothreshold/main.py
@@ -81,7 +81,7 @@ def compute_overlaps_all_parallel(
         #print(ith,flush=True)
 
 
-        if len(ids_threshold[ith]) == 0:
+        if len(ids_selected[ids_threshold[ith]]) == 0:
             sor_by_vol[ith] = np.zeros(0,dtype=np.int64)
             #self.id_out[ith][frac_ovlp] = np.zeros(0,dtype=np.int64)
 
@@ -96,7 +96,7 @@ def compute_overlaps_all_parallel(
         ids_ovlp[ith], Vol_ovlp, Vol_ovlp_frac[ith], num_ovlps[ith] = overlapping_fraction(
             Xcm[:,ids_threshold[ith],:], Vol_interp[:,ids_threshold[ith]], Ncells_in_void[:,ids_threshold[ith]], VoroXYZ, VoroVol, ID_voro_dict,
             Lbox=Lbox,lightcone=lightcone,id_selected=ids_selected[ids_threshold[ith]],nthreads=nthreads,verbose=verbose)
-        sor_by_vol[ith] = (np.argsort(Vol_interp[ids_selected[ith],ith])[::-1]).astype(dtype=np.int64, order='C')
+        sor_by_vol[ith] = (np.argsort(Vol_interp[ids_selected[ids_threshold[ith]],ith])[::-1]).astype(dtype=np.int64, order='C')
 
 
     id_out_dict, len_ids_out = compute_overlaps_all_parallel_compiled(


### PR DESCRIPTION
## Summary

The empty-array guard added in 32ea93b in `compute_overlaps_all_parallel` indexed the wrong array:

```python
if len(ids_threshold[ith]) == 0:   # ids_threshold[ith] is a scalar np.int64
```

`ids_threshold` is a 1-D array of threshold *indices* (`np.arange(len(self.threshold))`), so `ids_threshold[ith]` is a scalar and `len()` raises `TypeError` on every threshold, not just the empty ones. This makes the parallel branch of `compute_overlaps` unusable for all callers — the notebook below reproduces it with a single threshold and a single overlap fraction.

The guard should mirror the equivalent checks in the scalar branch (`main.py:426`) and in `compute_overlaps_all_test` (`main.py:510`), which both check `len(self.ids_selected[ith]) == 0`. In the parallel context, `ith` is a positional index into `ids_threshold`, so the correct dict key is `ids_threshold[ith]`.

## Changes

Two-line fix in `vorothreshold/main.py`:
- Line 84: `len(ids_threshold[ith])` → `len(ids_selected[ids_threshold[ith]])`
- Line 99: `Vol_interp[ids_selected[ith],ith]` → `Vol_interp[ids_selected[ids_threshold[ith]],ith]` (latent bug in the same function — same root cause, produces silently wrong results whenever `ids_threshold` is not the contiguous arange).

## Reproducer

```python
th_voids = voronoi_threshold_finder([0.3], lightcone=False, vide_path=void_dir)
th_voids.compute_overlaps(np.array([0.]), verbose=False)
# TypeError: object of type "numpy.int64" has no len()
```

## Test plan

- [ ] Re-run the failing notebook cell after the fix
- [ ] Confirm `compute_overlaps` with multiple thresholds + multiple overlap fractions still works
